### PR TITLE
投票コントラクトに関数やイベントを追加

### DIFF
--- a/contracts/Voting.sol
+++ b/contracts/Voting.sol
@@ -6,44 +6,49 @@ pragma solidity ^0.8.28;
  * @dev シンプルな二者択一の投票システムを実装したスマートコントラクト
  */
 contract Voting {
-    // 各オプションの得票数を記録
-    mapping(string => uint256) private votes;
-    // 投票済みのアドレスを記録
-    mapping(address => bool) public hasVoted;
+  // 各オプションの得票数を記録
+  mapping(string => uint256) private votes;
+  // 投票済みのアドレスを記録
+  mapping(address => bool) public hasVoted;
 
-    // 投票オプション：A または B
-    string[2] public options = ["A", "B"];
+  // 投票オプション：A または B
+  string[2] public options = ["A", "B"];
 
-    /**
-     * @dev 指定されたオプションに投票する
-     * @param option 投票するオプション（"A" または "B"）
-     * @notice 各アドレスは1回のみ投票可能
-     */
-    function vote(string memory option) public {
-        require(!hasVoted[msg.sender], "Already voted");
-        require(isValidOption(option), "Invalid option");
+  // 投票イベントを定義
+  event Voted(address indexed voter, string option);
 
-        votes[option]++;
-        hasVoted[msg.sender] = true;
-    }
+  /**
+   * @dev 指定されたオプションに投票する
+   * @param option 投票するオプション（"A" または "B"）
+   * @notice 各アドレスは1回のみ投票可能
+   */
+  function vote(string memory option) public {
+    require(!hasVoted[msg.sender], "Already voted");
+    require(isValidOption(option), "Invalid option");
 
-    /**
-     * @dev 指定されたオプションの得票数を取得
-     * @param option 得票数を確認するオプション（"A" または "B"）
-     * @return 指定されたオプションの得票数
-     */
-    function getVotes(string memory option) public view returns (uint256) {
-        require(isValidOption(option), "Invalid option");
-        return votes[option];
-    }
+    votes[option]++;
+    hasVoted[msg.sender] = true;
 
-    /**
-     * @dev 指定されたオプションが有効かどうかを確認
-     * @param option 確認するオプション
-     * @return オプションが有効な場合はtrue、それ以外はfalse
-     */
-    function isValidOption(string memory option) internal pure returns (bool) {
-        return (keccak256(abi.encodePacked(option)) == keccak256(abi.encodePacked("A")) ||
-                keccak256(abi.encodePacked(option)) == keccak256(abi.encodePacked("B")));
-    }
+    emit Voted(msg.sender, option);
+  }
+
+  /**
+   * @dev 指定されたオプションの得票数を取得
+   * @param option 得票数を確認するオプション（"A" または "B"）
+   * @return 指定されたオプションの得票数
+   */
+  function getVotes(string memory option) public view returns (uint256) {
+    require(isValidOption(option), "Invalid option");
+    return votes[option];
+  }
+
+  /**
+   * @dev 指定されたオプションが有効かどうかを確認
+   * @param option 確認するオプション
+   * @return オプションが有効な場合はtrue、それ以外はfalse
+   */
+  function isValidOption(string memory option) internal pure returns (bool) {
+    return (keccak256(abi.encodePacked(option)) == keccak256(abi.encodePacked("A")) ||
+              keccak256(abi.encodePacked(option)) == keccak256(abi.encodePacked("B")));
+  }
 }

--- a/contracts/Voting.sol
+++ b/contracts/Voting.sol
@@ -42,6 +42,17 @@ contract Voting {
     return votes[option];
   }
 
+  //
+  /**
+   * @dev 投票の結果を1回で全て取得する
+   * @return votesA オプションAの得票数
+   * @return votesB オプションBの得票数
+   */
+  function getAllVotes() public view returns (uint256 votesA, uint256 votesB) {
+    votesA = votes["A"];
+    votesB = votes["B"];
+  }
+
   /**
    * @dev 指定されたオプションが有効かどうかを確認
    * @param option 確認するオプション


### PR DESCRIPTION
# 変更内容

## 1. 投票イベントの追加
- `Voted`イベントを追加し、投票時にユーザーのアドレスと選択したオプションを記録
- フロントエンド側で投票状況のリアルタイム監視が可能に

## 2. 全投票結果取得機能の追加
- `getAllVotes()`関数を追加
- オプションAとBの得票数を1回のトランザクションで取得可能
- ガス代の節約とフロントエンド実装の効率化

## 3. 投票関数の拡張
- `vote()`関数に`Voted`イベントの発行を追加
- 投票の透明性と追跡可能性を向上

# 技術的な影響
- イベントの追加によりブロックチェーン上での投票追跡が容易に
- 複数の得票数取得を1回のトランザクションに最適化
- スマートコントラクトの機能と使いやすさを向上