### PR TITLE
Update frontend env instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ npx hardhat ignition deploy ./ignition/modules/Voting.ts --network sepolia
 ```
 
 3. フロントエンド設定を更新
-   デプロイされたコントラクトアドレスを `frontend/src/config/` に設定
+   デプロイされたコントラクトアドレスを `frontend/.env.local` の `NEXT_PUBLIC_VOTING_CONTRACT_ADDRESS` に設定
 
 ### 開発サーバー起動
 


### PR DESCRIPTION
## Summary
- clarify frontend configuration steps in README

## Testing
- `npm install`
- `npx hardhat test` *(fails: Invalid account/private key)*

------
https://chatgpt.com/codex/tasks/task_e_6844012dbf808320a9adf9431b35ff74